### PR TITLE
fix: remove unused arch vars; remove hostname 2nd check in 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,21 +1,19 @@
 ---
-
 # Project source code URL: https://github.com/Sonarr/Sonarr
 
 sonarr_enabled: true
 
 sonarr_identifier: sonarr
 
-sonarr_uid: ''
-sonarr_gid: ''
-sonarr_timezone: 'Etc/UTC'
+sonarr_uid: ""
+sonarr_gid: ""
+sonarr_timezone: "Etc/UTC"
 
 # renovate: datasource=docker depName=lscr.io/linuxserver/sonarr versioning=semver
 sonarr_version: 4.0.15
-sonarr_arch: amd64
 
 # The hostname at which sonarr is served.
-sonarr_hostname: ''
+sonarr_hostname: ""
 
 # The path at which sonarr is served.
 # This value must either be `/` or not end with a slash (e.g. `/sonarr`).
@@ -75,7 +73,7 @@ sonarr_container_labels_traefik_rule: "Host(`{{ sonarr_container_labels_traefik_
 sonarr_container_labels_traefik_priority: 0
 sonarr_container_labels_traefik_entrypoints: web-secure
 sonarr_container_labels_traefik_tls: "{{ sonarr_container_labels_traefik_entrypoints != 'web' }}"
-sonarr_container_labels_traefik_tls_certResolver: default  # noqa var-naming
+sonarr_container_labels_traefik_tls_certResolver: default # noqa var-naming
 
 # sonarr_container_labels_additional_labels contains a multiline string with additional labels to add to the container label file.
 # See `../templates/labels.j2` for details.
@@ -84,7 +82,7 @@ sonarr_container_labels_traefik_tls_certResolver: default  # noqa var-naming
 # sonarr_container_labels_additional_labels: |
 #   my.label=1
 #   another.label="here"
-sonarr_container_labels_additional_labels: ''
+sonarr_container_labels_additional_labels: ""
 
 # sonarr_container_additional_environment_variables contains a multiline string with additional environment variables to pass to the container.
 #
@@ -92,7 +90,7 @@ sonarr_container_labels_additional_labels: ''
 # sonarr_container_additional_environment_variables: |
 #   VAR=1
 #   ANOTHER=value
-sonarr_container_additional_environment_variables: ''
+sonarr_container_additional_environment_variables: ""
 
 # A list of additional "volumes" to mount in the container.
 #

--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Fail if required Sonarr settings not defined
   ansible.builtin.fail:
     msg: >
@@ -8,14 +7,6 @@
   with_items:
     - sonarr_uid
     - sonarr_gid
-    - sonarr_hostname
-
-- name: Fail if Sonarr architecture is not supported
-  ansible.builtin.fail:
-    msg: >
-      Your configuration specifies a CPU architecture (`{{ sonarr_arch }}`) which is not currently supported.
-      This Sonarr role also does not support self-building yet, so it's not possible to make use of it.
-  when: "sonarr_arch not in ['amd64', 'arm64']"
 
 - name: Validate Sonarr Traefik configuration
   when: sonarr_container_labels_traefik_enabled | bool


### PR DESCRIPTION
This PR removes the unused sonarr_arch part and eliminates the test in validate_config that enforces the definition of a hostname. The hostname is only required if sonarr_container_labels_traefik_enabled is set to true.

Same changes as to be done in radarr and jackett too