### PR TITLE
Update sonarr.service.j2 fix lstrip issue

### DIFF
--- a/templates/systemd/sonarr.service.j2
+++ b/templates/systemd/sonarr.service.j2
@@ -1,4 +1,4 @@
-#jinja2: lstrip_blocks: "True"
+#jinja2: lstrip_blocks: True
 [Unit]
 Description=Sonarr ({{ sonarr_identifier }})
 {% for service in sonarr_systemd_required_services_list %}


### PR DESCRIPTION
Fix : TemplateOverrides.lstrip_blocks must be <class 'bool'> instead of <class 'str'> issue